### PR TITLE
Rename Restriction to Consent

### DIFF
--- a/FHIR-us-directory-attestation.xml
+++ b/FHIR-us-directory-attestation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/directory-attestation/2022Sep" ciUrl="http://build.fhir.org/ig/HL7/directory-attestation" defaultVersion="1.0.0-ballot" defaultWorkgroup="pa" gitUrl="https://github.com/HL7/fhir-directory-attestation" url="http://hl7.org/fhir/us/directory-attestation">
-<version code="current" url="http://build.fhir.org/ig/HL7/directory-attestation"/>
+<specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/directory-attestation/2022Sep" ciUrl="http://build.fhir.org/ig/HL7/fhir-directory-attestation" defaultVersion="1.0.0-ballot" defaultWorkgroup="pa" gitUrl="https://github.com/HL7/fhir-directory-attestation" url="http://hl7.org/fhir/us/directory-attestation">
+<version code="current" url="http://build.fhir.org/ig/HL7/fhir-directory-attestation"/>
 <version code="1.0.0-ballot" url="http://hl7.org/fhir/us/directory-attestation/2022Sep"/>
 <artifactPageExtension value="-definitions"/>
 <artifactPageExtension value="-examples"/>
@@ -66,7 +66,8 @@
 <artifact id="StructureDefinition/NatlDirAttest-HealthcareService" key="StructureDefinition-NatlDirAttest-HealthcareService" name="National Directory HealthcareService"/>
 <artifact id="CapabilityStatement/NatlDir" key="CapabilityStatement-NatlDir" name="NatlDir CapabilityStatement"/>
 <artifact id="StructureDefinition/NatlDir-Validation" key="StructureDefinition-NatlDir-Validation" name="NatlDir Validation"/>
-<artifact id="StructureDefinition/NatlDirEx-restriction" key="StructureDefinition-NatlDirEx-restriction" name="NatlDirEx Restriction"/>
+<artifact id="StructureDefinition/NatlDirEx-consent" key="StructureDefinition-NatlDirEx-consent" name="NatlDirEx Consent"/>
+<artifact deprecated="true" id="StructureDefinition/NatlDirEx-restriction" key="StructureDefinition-NatlDirEx-restriction" name="NatlDirEx Restriction"/>
 <artifact id="SearchParameter/endpoint-organization" key="SearchParameter-endpoint-organization" name="NatlDir_sp_endpoint_organization"/>
 <artifact id="SearchParameter/healthcareservice-service-category" key="SearchParameter-healthcareservice-service-category" name="NatlDir_sp_healthcareservice_category"/>
 <artifact id="SearchParameter/healthcareservice-coverage-area" key="SearchParameter-healthcareservice-coverage-area" name="NatlDir_sp_healthcareservice_coverage_area"/>

--- a/FHIR-us-fhir-directory-attestation.xml
+++ b/FHIR-us-fhir-directory-attestation.xml
@@ -66,7 +66,7 @@
 <artifact id="StructureDefinition/NatlDirAttest-HealthcareService" key="StructureDefinition-NatlDirAttest-HealthcareService" name="National Directory HealthcareService"/>
 <artifact id="CapabilityStatement/NatlDir" key="CapabilityStatement-NatlDir" name="NatlDir CapabilityStatement"/>
 <artifact id="StructureDefinition/NatlDir-Validation" key="StructureDefinition-NatlDir-Validation" name="NatlDir Validation"/>
-<artifact id="StructureDefinition/NatlDirEx-restriction" key="StructureDefinition-NatlDirEx-restriction" name="NatlDirEx Restriction"/>
+<artifact id="StructureDefinition/NatlDirEx-consent" key="StructureDefinition-NatlDirEx-consent" name="NatlDirEx Consent"/>
 <artifact id="SearchParameter/endpoint-organization" key="SearchParameter-endpoint-organization" name="NatlDir_sp_endpoint_organization"/>
 <artifact id="SearchParameter/healthcareservice-service-category" key="SearchParameter-healthcareservice-service-category" name="NatlDir_sp_healthcareservice_category"/>
 <artifact id="SearchParameter/healthcareservice-coverage-area" key="SearchParameter-healthcareservice-coverage-area" name="NatlDir_sp_healthcareservice_coverage_area"/>

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -89,7 +89,7 @@ Alias: $consent = https://hl7.org/fhir/uv/vhdir/2018Sep/vhdir/ValueSet/consent
 
 Alias: $NatlDirExOrganizationAffiliation =	http://hl7.org/fhir/us/directory-query/StructureDefinition/NatlDirEndpointQry-OrganizationAffiliation
 Alias: $NatlDirEndpointQryPractitionerRoleCode = http://hl7.org/fhir/us/directory-query/CodeSystem/ProviderRoleCS
-Alias: $NatlDirectoryRestriction  =	    http://hl7.org/fhir/us/directory-query/StructureDefinition/NatlDir-Restriction
+Alias: $NatlDirectoryRestriction  =	    http://hl7.org/fhir/us/directory-query/StructureDefinition/NatlDir-Consent
 Alias: $NatlDirectoryValidation  =	    http://hl7.org/fhir/us/directory-query/StructureDefinition/NatlDir-Verification
 Alias: $NatlDirectoryEndpointTypeCS  =	    http://hl7.org/fhir/us/directory-query/CodeSystem/EndpointTypeCS
 Alias: $NatlDirectoryHealthcareServiceDeliveryMthdCS  =	    http://hl7.org/fhir/us/directory-query/CodeSystem/DeliveryMethodCS

--- a/input/fsh/NatlDirectory.fsh
+++ b/input/fsh/NatlDirectory.fsh
@@ -149,79 +149,46 @@ Description: "Describes validation requirements, source(s), status and dates for
 
 
 
-Profile:  NatlDirAttestUsageRestriction
+Profile:  NatlDirAttestUsageConsent
 Parent: Consent
-Id:  NatlDirEx-restriction
-Title: "NatlDirEx Restriction"
+Id:  NatlDirEx-consent
+Title: "NatlDirEx Consent"
 Description: "Restriction on use/release of exchanged information"
 * ^status = #active
 * ^date = "2017-12-15T01:01:31.325+11:00"
 * . ^short = "A policy may permit or deny recipients or roles to perform actions for specific purposes and periods of time"
-* . ^alias = "Restriction"
-* identifier ..0 MS
 * status MS
 * status ^short = "Indicates the current state of this restriction"
 * status ^comment = "This element is labeled as a modifier because the status contains the codes rejected and entered-in-error that mark the restriction as not currently valid."
-* scope MS
-// Creates a dependency on an old specification that was never officially published
-//* scope from $consent (extensible)
-* scope ^binding.extension.url = "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName"
-* scope ^binding.extension.valueString = "ConsentScope"
 * category MS
 * category ^label = "Type"
 * category ^short = "Type of restriction"
 * category ^definition = "Type of restriction (conditional release (per DUA); requires flowdown agreement (for redisclosure); internal use only; release defined by access rights (as specified by the national source))"
-* patient ..0 MS
 * dateTime MS
 * dateTime ^label = "last updated"
 * dateTime ^short = "date/time of last update for this restriction"
 * dateTime ^definition = "When this Restriction was issued / created / indexed."
-* performer ..0 MS
-* organization ..0 MS
-* source[x] ..0 MS
 * policy MS
 * policy.authority ..0 MS
 * policy.uri MS
 * policy.uri ^short = "Specific policy covered by this restriction"
-//* policyRule ..0 MS
-* verification ..0 MS
-* verification.verified MS
-* verification.verifiedWith MS
-* verification.verificationDate MS
 * provision MS
 * provision ^short = "Access rights"
-* provision.type = #permit (exactly)
-* provision.type MS
-* provision.period ..0 MS
-* provision.actor 1.. MS
-* provision.actor.role MS
-* provision.actor.reference only Reference( Organization or  CareTeam or  Practitioner)
-* provision.actor.reference MS
-* provision.actor.reference ^short = "definedUserOrGroup"
-* provision.action ..1 MS
-* provision.action ^short = "reasonType"
-* provision.action ^definition = "Describes how the reference is related to the restriction (contributes to; reason for; existance of; specific value)"
-* provision.securityLabel MS
-* provision.securityLabel ^short = "userType"
-* provision.purpose MS
-* provision.purpose ^short = "reasonName"
-* provision.purpose ^definition = "Name assigned to the restriction condition"
-* provision.class ..0 MS
-* provision.code ..0 MS
-* provision.dataPeriod ..0 MS
-* provision.data ..0 MS
-* provision.data.meaning MS
-* provision.data.reference MS
-* provision.provision ..0 MS
+* provision.type = #deny (exactly) 
+* provision.provision.type = #permit (exactly)
+* provision.provision.type MS
+* provision.provision.actor 1..* MS
+* provision.provision.actor.role 1..1 MS
+* provision.provision.securityLabel 1..* MS
+* provision.provision.class 1..* 
 
 
-
-Extension: NatlDirAttestUsageRestriction
+Extension: NatlDirAttestUsageConsent
 Id: natlDirAtt-usage-restriction
 Title: "NatlDirExr Usage Restriction"
-Description: """The FHIR specification contains a security meta tag which can be used to inform systems of the sensitivity of resources, as well as by access control mechanisms to ensure content isn't exposed that shouldn't be.
+Description: "The FHIR specification contains a security meta tag which can be used to inform systems of the sensitivity of resources, as well as by access control mechanisms to ensure content isn't exposed that shouldn't be.
 This mechanism only goes to the resource level, this reference to a usage-restriction (consent) extends this further into the resource, and can be applied to any element, and may apply to all properties beneath the element (e.g. If applied to an identifier on a practitioner, then all the properties of the identifier should not be exposed unless it is understood)
-This will be expected to be used as a modifier extension."""
+This will be expected to be used as a modifier extension."
 * ^context.type = #fhirpath
 * ^context.expression = "descendants()"
 * ^date = "2017-10-20T10:59:36.931+11:00"

--- a/input/fsh/RestrictionVerificationExamples.fsh
+++ b/input/fsh/RestrictionVerificationExamples.fsh
@@ -1,8 +1,8 @@
 Instance: PatientConsent
-InstanceOf: NatlDirAttestUsageRestriction
+InstanceOf: NatlDirAttestUsageConsent
 Description: "Patient that gives consent"
 Usage: #example 
-* meta.profile = Canonical(NatlDirAttestUsageRestriction) 
+* meta.profile = Canonical(NatlDirAttestUsageConsent) 
 * meta.lastUpdated = "2020-07-07T13:26:22.0314215+00:00"
 * status  = $ConsentCS#active
 * scope = $NatlDirectoryConsentScopeCS#patient-privacy


### PR DESCRIPTION
The 'Restriction' profile adds an unneeded level of abstraction, which makes implementation more difficult.  The 'restriction' terminology should refer to security labels in the `Consent.provision.provision.securityLabel` field.  Additionally, the profile should enforce a double level provision model, so as to preserve compatibility with Consent resources acquired via Advanced Directives and other sources.   